### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/par_cc_usage/webhook_client.py
+++ b/src/par_cc_usage/webhook_client.py
@@ -46,7 +46,7 @@ class WebhookClient:
         Returns:
             Detected webhook type
         """
-        if "discord.com" in webhook_url.lower():
+        if urlparse(webhook_url).hostname == "discord.com":
             return WebhookType.DISCORD
         elif urlparse(webhook_url).hostname == "hooks.slack.com":
             return WebhookType.SLACK


### PR DESCRIPTION
Potential fix for [https://github.com/DiologIR/cc_usage/security/code-scanning/3](https://github.com/DiologIR/cc_usage/security/code-scanning/3)

To fix the issue, the validation should use the `urlparse` function to parse the URL and then check its `hostname` for the expected value. This prevents substring-based bypasses and ensures that only legitimate hostnames are accepted.

Specifically:
- Replace the `if "discord.com" in webhook_url.lower()` check with a `urlparse(webhook_url).hostname == "discord.com"` check.
- This change ensures the hostname of the parsed URL matches `discord.com` directly, eliminating the possibility of embedded substrings causing false positives.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
